### PR TITLE
Typos & Deprecated Kwarg

### DIFF
--- a/3b-ai_assisted/pandas_copilot.ipynb
+++ b/3b-ai_assisted/pandas_copilot.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That generated a scary looking error message! This is human error, not AI error. But before we sort that out, let's marvel at what Copilot did there. We gave it a pretty poor prompt (\"the gapminder data for europe\"), and it guessed that the file was named `gapminder_europe.csv`. It also guessed that we wanted to use the `pandas` library (`pd`) to read the CSV file into a `DataFrame`. That's pretty impressive!\n",
+    "That generated a scary looking error message! This is human error, not AI error. But before we sort that out, let's marvel at what Copilot did there. We gave it a pretty poor prompt (\"the gapminder data for europe\"), and it guessed that the file was named `gapminder_gdp_europe.csv`. It also guessed that we wanted to use the `pandas` library (`pd`) to read the CSV file into a `DataFrame`. That's pretty impressive!\n",
     "\n",
     "Fortunately, the error is pretty self-explanatory. If we want to work with pandas, we always need to first import the pandas library. By convention we give it the alias `pd`. So let's add that to our prompt, and see what happens. Note that Copilot may generate code one line at a time, so you may have to accept the suggestion for the first line of code before it generates the next line of code."
    ]

--- a/3b-ai_assisted/rt_data.ipynb
+++ b/3b-ai_assisted/rt_data.ipynb
@@ -509,7 +509,7 @@
     }
    ],
    "source": [
-    "# what is the fasted reaction time in the dataset\n",
+    "# what is the fastest reaction time in the dataset\n",
     "min(rt)\n"
    ]
   },
@@ -584,7 +584,7 @@
     "\n",
     "In behavioral experiments it's common to analyze both reaction times and error rates. The list below contains a value for each trial indicating whther the subject made an error (`True`) or not (`False`). \n",
     "\n",
-    "Note that it might be more intuitive if this were coded as `True` for correct responses, and `False` for errors, but the variable is recording errors, not accuracy. It's always important in data science to make sure you undersatnd what your data represent!"
+    "Note that it might be more intuitive if this were coded as `True` for correct responses, and `False` for errors, but the variable is recording errors, not accuracy. It's always important in data science to make sure you understand what your data represents!"
    ]
   },
   {

--- a/4-viz/seaborn.ipynb
+++ b/4-viz/seaborn.ipynb
@@ -1210,7 +1210,7 @@
    "id": "51b144e1-cdb4-4c35-9733-8e3b81a3ac90",
    "metadata": {},
    "source": [
-    "We can remove the lines with `join=False`, and color-code the different levels of condition with `hue='condition'`"
+    "We can remove the lines with `linestyle='none'`, and color-code the different levels of condition with `hue='condition'`"
    ]
   },
   {
@@ -1233,7 +1233,7 @@
     }
    ],
    "source": [
-    "sns.catplot(kind='point', join=False, hue='condition',\n",
+    "sns.catplot(kind='point', linestyle='none', hue='condition',\n",
     "           data=df, \n",
     "           x='condition', y='RT')\n",
     "\n",

--- a/5-eda/repeated_measures.ipynb
+++ b/5-eda/repeated_measures.ipynb
@@ -473,7 +473,7 @@
     }
    ],
    "source": [
-    "sns.catplot(kind='point', join=False,\n",
+    "sns.catplot(kind='point', linestyle='none',\n",
     "           data=df,\n",
     "           x='flankers', y='rt', hue='flankers')\n",
     "plt.show()"
@@ -944,7 +944,7 @@
     }
    ],
    "source": [
-    "sns.catplot(kind='point', join=False,\n",
+    "sns.catplot(kind='point', linestyle='None',\n",
     "           data=df, units='participant',\n",
     "           x='flankers', y='rt', hue='flankers')\n",
     "plt.show()"
@@ -1449,7 +1449,7 @@
     }
    ],
    "source": [
-    "sns.catplot(kind='point', join=False,\n",
+    "sns.catplot(kind='point', linestyle='none',\n",
     "           data=df_avg,\n",
     "           x='flankers', y='rt', hue='flankers',\n",
     "           order=['congruent', 'neutral', 'incongruent'])\n",

--- a/5-eda/ttests.ipynb
+++ b/5-eda/ttests.ipynb
@@ -340,7 +340,7 @@
    "id": "ab284c88-df8e-4b2e-bc1f-ec7fb8cc130c",
    "metadata": {},
    "source": [
-    "Now that's a results any researcher would be happy to see! The *p* value is not actually zero by the way, but note in the original output the *p* value was reported in scientific notation, ending in `e-10`. This means that the *p* value is actually 0.00000000013739. We would typically report this as *p* < .0001, since we rounded to 4 decimal places (which is fairly typical for reporting *p* values), but Python simply rounds the value as we asked."
+    "Now that's a result any researcher would be happy to see! The *p* value is not actually zero by the way, but note in the original output the *p* value was reported in scientific notation, ending in `e-10`. This means that the *p* value is actually 0.00000000013739. We would typically report this as *p* < .0001, since we rounded to 4 decimal places (which is fairly typical for reporting *p* values), but Python simply rounds the value as we asked."
    ]
   },
   {


### PR DESCRIPTION
Some self-explanatory typos and a deprecated kwarg noticed from the following error:

> [/tmp/ipykernel_9245/3023065820.py:1](https://file+.vscode-resource.vscode-cdn.net/tmp/ipykernel_9245/3023065820.py:1): UserWarning: The `join` parameter is deprecated and will be removed in v0.15.0. You can remove the line between points with `linestyle='none'`.